### PR TITLE
Update typo in NTR.BA cell and add comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Border_Adjustment_Calculator
-=================================
 
 The code in this repo generates a 
 [web-page](https://ospc.shinyapps.io/border-adjustment-calculator/) 

--- a/server.R
+++ b/server.R
@@ -11,63 +11,56 @@ function(input, output) {
                "Taxes",
                "After Tax Profit"),
       "OTR" = as.character(c(
-                                   round(input$c5,digits = 1),
-                                   round((1-input$c5/100)*100,digits = 1), 
-                                   round(input$c6*input$c7/100,digits = 1),
-                                   round((1-input$c7/100)*input$c6,digits = 1),
-                                   round(input$c5+(1-input$c5/100)*100
-                                   -input$c6*input$c7/100-(1-input$c7/100)*input$c6,digits = 1),
-                                   round(0.01*35*((input$c5)+((1-input$c5/100)*100)
-                                               -(input$c6*input$c7/100)-((1-input$c7/100)*input$c6)),digits = 1),
-                                   round((input$c5+(1-input$c5/100)*100-
-                                     input$c6*input$c7/100-(1-input$c7/100)*input$c6- 
-                                          (0.01*35*(input$c5+(1-input$c5/100)*100
-                                    -input$c6*input$c7/100-(1-input$c7/100)*input$c6)))*100,-1)/100
-                                    )),
+                round(input$c5,digits = 1), # US Sales
+                round((1-input$c5/100)*100,digits = 1), # Foreign Sales
+                round(input$c6*input$c7/100,digits = 1), # US Costs 
+                round((1-input$c7/100)*input$c6,digits = 1), # Foreign Costs
+                round(input$c5+(1-input$c5/100)*100  # Tax Base
+                  -input$c6*input$c7/100-(1-input$c7/100)*input$c6,digits = 1),
+                round(0.01*35*((input$c5)+((1-input$c5/100)*100) # Taxes
+                  -(input$c6*input$c7/100)-((1-input$c7/100)*input$c6)),digits = 1),
+                round((input$c5+(1-input$c5/100)*100 - # After Tax Profit
+                  input$c6*input$c7/100-(1-input$c7/100)*input$c6- 
+                    (0.01*35*(input$c5+(1-input$c5/100)*100-
+                      input$c6*input$c7/100-(1-input$c7/100)*input$c6)))*10)/10
+                )),
       
-      "NTR" = as.character(c(round(input$c5,digits = 1),
-                                   round((1-input$c5/100)*100,digits = 1),
-                                   round(input$c6*input$c7/100,digits = 1),
-                                   round((1-input$c7/100)*input$c6,digits = 1),
-                                   round(round(input$c5,digits = 2)+
-                                     round((1-input$c5/100)*100,digits = 2)-
-                                     round(input$c6*input$c7/100,digits = 2)-
-                                     round((1-input$c7/100)*input$c6,digits = 2),digits = 1),
-                                   round(0.01*input$c8*(round(input$c5,digits = 2)+
-                                                          round((1-input$c5/100)*100,digits = 2)-
-                                                          round(input$c6*input$c7/100,digits = 2)-
-                                                          round((1-input$c7/100)*input$c6,digits = 2)),digits = 1),
-                                   round((input$c5 +
-                                     (1-input$c5/100)*100 -
-                                     input$c6*input$c7/100 -
-                                     (1-input$c7/100)*input$c6 - 0.01*input$c8*(input$c5+
-                                          (1-input$c5/100)*100 -
-                                      input$c6*input$c7/100-
-                                      (1-input$c7/100)*input$c6))*100,-1)/100)),
+      "NTR" = as.character(c(
+                round(input$c5,digits = 1), # US Sales
+                round((1-input$c5/100)*100,digits = 1), # Foreign Sales
+                round(input$c6*input$c7/100,digits = 1), # US Costs 
+                round((1-input$c7/100)*input$c6,digits = 1), # Foreign Costs
+                round(input$c5 + (1-input$c5/100)*100 - # Tax Base
+                  input$c6*input$c7/100- (1-input$c7/100)*input$c6,digits = 1),
+                round(0.01*input$c8*(input$c5 + (1-input$c5/100)*100- # Taxes
+                  input$c6*input$c7/100-(1-input$c7/100)*input$c6),digits = 1),
+                round((input$c5 + (1-input$c5/100)*100 - # After Tax Profit
+                  input$c6*input$c7/100 -
+                    (1-input$c7/100)*input$c6 - 0.01*input$c8*(input$c5+
+                      (1-input$c5/100)*100 - input$c6*input$c7/100-
+                        (1-input$c7/100)*input$c6))*10)/10
+                )),
       
-     "NTR.BA" = as.character(c(  round(input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))-
-                                                    ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0),digits = 1),
-                                  round((1-input$c5/100)*100*(1-input$c8*input$c9/10000),digits = 1),
-                                  round(input$c6*input$c7/100,digits = 1),
-                                  round((1-input$c7/100)*input$c6*(1-input$c8*input$c9/10000),digits = 1),
-                                  round(input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))-
-                                                         ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0)
-                                     - input$c6*input$c7/100,digits = 1),
-                                  round(0.01*input$c8*(input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))-
-                                                                           ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0) 
-                                                       - input$c6*input$c7/100),digits = 1),
-                                 
-                               round(
-                                 input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))-
-                                              ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0) +
-                                   (1-input$c5/100)*100*(1-input$c8*input$c9/10000) -
-                                 input$c6*input$c7/100 -
-                                 (1-input$c7/100)*input$c6*(1-input$c8*input$c9/10000) -
-                                   (0.01*input$c8*(input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))-
-                                                                     ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0) 
-                                                   - input$c6*input$c7/100))
-                                    ,1)
-                                  )), 
+     "NTR.BA" = as.character(c( 
+                round(input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))- # US Sales
+                  ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0),digits = 1),
+                round((1-input$c5/100)*100*(1-input$c8*input$c9/10000),digits = 1), # Foreign Sales
+                round(input$c6*input$c7/100,digits = 1), # US Costs 
+                round((1-input$c7/100)*input$c6*(1-input$c8*input$c9/10000),digits = 1), # Foreign Costs
+                round(input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))- # Tax Base
+                  ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0)
+                    - input$c6*input$c7/100,digits = 1),
+                round(0.01*input$c8*(input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))- # Taxes
+                  ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0) 
+                    - input$c6*input$c7/100),digits = 1),               
+                round(input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))- # After Tax Profit
+                  ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0) +
+                    (1-input$c5/100)*100*(1-input$c8*input$c9/10000) - input$c6*input$c7/100 -
+                      (1-input$c7/100)*input$c6*(1-input$c8*input$c9/10000) -
+                        (0.01*input$c8*(input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))-
+                          ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0) 
+                            - input$c6*input$c7/100)),1)
+                )), 
       stringsAsFactors=FALSE)
   }) 
   output$values <- renderTable({

--- a/server.R
+++ b/server.R
@@ -57,15 +57,16 @@ function(input, output) {
                                                                            ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0) 
                                                        - input$c6*input$c7/100),digits = 1),
                                  
-                               round(100*(
+                               round(
                                  input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))-
-                                              ((1-input$c5/100)*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/100,0) +
-                               (1-input$c5/100)*(100-input$c8*input$c9/100) -
-                                 input$c6*input$c7/100-
+                                              ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0) +
+                                   (1-input$c5/100)*100*(1-input$c8*input$c9/10000) -
+                                 input$c6*input$c7/100 -
                                  (1-input$c7/100)*input$c6*(1-input$c8*input$c9/10000) -
-                                 0.01*input$c8*(input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))-
-                                      ((1-input$c5/100)*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/100,0) 
-                                              - input$c6*input$c7/100)),-1)/100
+                                   (0.01*input$c8*(input$c5 + max((((1-input$c7/100)*input$c6*(1-input$c9/100))-
+                                                                     ((1-input$c5/100)*100*(1-input$c9/100)))*input$c8*(1/(1-input$c8/100))*input$c10/10000,0) 
+                                                   - input$c6*input$c7/100))
+                                    ,1)
                                   )), 
       stringsAsFactors=FALSE)
   }) 


### PR DESCRIPTION
Previously, as pointed out by @MattHJensen, there's one typo in the code so that the [webpage](https://ospc.shinyapps.io/border-adjustment-calculator/) would yield erroneous result. The first commit fixes this typo. 

Next couple commits streamline the code, and added corresponding cell name to each row in the code line.

 Attached is the erroneous result on the webpage, which has now been fixed:

<img width="911" alt="pastedgraphic-8" src="https://cloud.githubusercontent.com/assets/13324931/21529486/ce1a51fe-cd07-11e6-9f00-e082ebfe60b8.png">
