### PR TITLE
Add test suites to Border Adjustment Calculator

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -21,7 +21,7 @@ After installation:
 Then, in the console type 
 ```
 library(testthat)
-test_dir("[YOURDIRECTORY]/Border-adjustment-calculator/tests", filter = 'numeric', reporter="summary")
+test_dir("[YOUR_DIRECTORY]/Border-adjustment-calculator/tests", filter = 'numeric', reporter="summary")
 ```
 and run. 
 
@@ -36,19 +36,19 @@ Troubleshoot
 ------------------
 Here are some typical errors we might run into:
 
-****Error 1****:
+***Error 1***:
 ```
 Error in library(testthat) : there is no package called ‘testthat’
 ```
 Reason: Package `testthat` is not installed.
 
-****Error 2****:
+***Error 2***:
 ```
 Error: could not find function "test_dir"
 ```
 Reason: Package `testthat` is not loaded, run `library(testthat)`.
 
-****Error 3****:
+***Error 3***:
 ```
 Failed ----------------------------------------------------------------------------------------------------------------------------
 1. Failure: Testing New Tax Rate #2 (@test-numeric.R#71) --------------------------------------------------------------------------

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,58 @@
+Test Suites for Border Adjustment Calculator
+======================================
+
+Test suites in this directory are designed to ensure Shiny server is running 
+properly, and to validate numeric outcomes using corner cases. We first
+introduce how to execute validation for numeric results. 
+
+Numeric Tests
+-------------------
+
+In order to run any of these tests, you need to have 
+[R](https://www.r-project.org/) installed. In addition to R, 
+[RStudio](https://www.rstudio.com/) is recommended but not necessary. 
+
+After installation:
+1. Launch R or RStudio;
+2. Open the Package Installer;
+3. Search for package `testthat`;
+4. Install it and all its dependencies.
+
+Then, in the console type 
+```
+library(testthat)
+test_dir("[YOURDIRECTORY]/Border-adjustment-calculator/tests", filter = 'numeric', reporter="summary")
+```
+and run. 
+
+We should expect the following output:
+```
+.............................................
+DONE ==============================================================================================================================
+```
+meaning that all 45 tests have passed. 
+
+Troubleshoot
+------------------
+Here are some typical errors we might run into:
+
+****Error 1****:
+```
+Error in library(testthat) : there is no package called ‘testthat’
+```
+Reason: Package `testthat` is not installed.
+
+****Error 2****:
+```
+Error: could not find function "test_dir"
+```
+Reason: Package `testthat` is not loaded, run `library(testthat)`.
+
+****Error 3****:
+```
+Failed ----------------------------------------------------------------------------------------------------------------------------
+1. Failure: Testing New Tax Rate #2 (@test-numeric.R#71) --------------------------------------------------------------------------
+result_ATP == 2.9 isn't true.
+```
+Reason: Changes to the calculator result in unexpected results and need to be reviewed. 
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,7 +3,8 @@ Test Suites for Border Adjustment Calculator
 
 Test suites in this directory are designed to ensure Shiny server is running 
 properly, and to validate numeric outcomes using corner cases. We first
-introduce how to execute validation for numeric results. 
+introduce how to execute validation for numeric results. Other tests are 
+coming soon.
 
 Numeric Tests
 -------------------
@@ -13,12 +14,13 @@ In order to run any of these tests, you need to have
 [RStudio](https://www.rstudio.com/) is recommended but not necessary. 
 
 After installation:
+
 1. Launch R or RStudio;
 2. Open the Package Installer;
 3. Search for package `testthat`;
 4. Install it and all its dependencies.
 
-Then, in the console type 
+Then, in the console, type 
 ```
 library(testthat)
 test_dir("[YOUR_DIRECTORY]/Border-adjustment-calculator/tests", filter = 'numeric', reporter="summary")
@@ -32,7 +34,7 @@ DONE ===========================================================================
 ```
 meaning that all 45 tests have passed. 
 
-Troubleshoot
+Troubleshooting
 ------------------
 Here are some typical errors we might run into:
 
@@ -50,9 +52,10 @@ Reason: Package `testthat` is not loaded, run `library(testthat)`.
 
 ***Error 3***:
 ```
+...........1.................................
 Failed ----------------------------------------------------------------------------------------------------------------------------
 1. Failure: Testing New Tax Rate #2 (@test-numeric.R#71) --------------------------------------------------------------------------
 result_ATP == 2.9 isn't true.
 ```
-Reason: Changes to the calculator result in unexpected results and need to be reviewed. 
+Reason: Changes to the calculator result in unexpected result(s) and need to be reviewed. 
 

--- a/tests/test-basic.R
+++ b/tests/test-basic.R
@@ -10,7 +10,7 @@ appURL <- "https://ospc.shinyapps.io/border-adjustment-calculator/"
 test_that("can connect to app", {  
   remDr$navigate(appURL)
   appTitle <- remDr$getTitle()[[1]]
-  expect_equal(appTitle, "Border-Adjustment-Calculator")  
+  expect_equal(appTitle, "border-adjustment-calculator")  
 })
 
 remDr$close()

--- a/tests/test-basic.R
+++ b/tests/test-basic.R
@@ -1,0 +1,16 @@
+context("basic")
+
+library(RSelenium)
+library(testthat)
+
+remDr <- remoteDriver()
+remDr$open(silent = TRUE)
+appURL <- "https://ospc.shinyapps.io/border-adjustment-calculator/"
+
+test_that("can connect to app", {  
+  remDr$navigate(appURL)
+  appTitle <- remDr$getTitle()[[1]]
+  expect_equal(appTitle, "Border-Adjustment-Calculator")  
+})
+
+remDr$close()

--- a/tests/test-numeric.R
+++ b/tests/test-numeric.R
@@ -1,52 +1,52 @@
 OTR_TB <- function(dom_costs, dom_sales, tot_sales){
-    return(round(dom_sales+(1-dom_sales/100)*100 
-                  -tot_sales*dom_costs/100-(1-dom_costs/100)*tot_sales,digits = 1))
+  return(round(dom_sales+(1-dom_sales/100)*100 
+               -tot_sales*dom_costs/100-(1-dom_costs/100)*tot_sales,digits = 1))
 }
 
 OTR_ATP <- function(dom_costs, dom_sales, tot_sales){
-    return(round((dom_sales+(1-dom_sales/100)*100 - 
+  return(round((dom_sales+(1-dom_sales/100)*100 - 
                   tot_sales*dom_costs/100-(1-dom_costs/100)*tot_sales- 
-                    (0.01*35*(dom_sales+(1-dom_sales/100)*100-
-                      tot_sales*dom_costs/100-(1-dom_costs/100)*tot_sales)))*10)/10
-    )
+                  (0.01*35*(dom_sales+(1-dom_sales/100)*100-
+                              tot_sales*dom_costs/100-(1-dom_costs/100)*tot_sales)))*10)/10
+  )
 }
 
 NTR_TB <- function(dom_costs, dom_sales, tot_sales){
-    return(round(dom_sales + (1-dom_sales/100)*100 -
-                  tot_sales*dom_costs/100- (1-dom_costs/100)*tot_sales,digits = 1)
-    )
+  return(round(dom_sales + (1-dom_sales/100)*100 -
+                 tot_sales*dom_costs/100- (1-dom_costs/100)*tot_sales,digits = 1)
+  )
 }
 
 NTR_ATP <- function(dom_costs, dom_sales, tot_sales, new_tax_rate){
-    return(round((dom_sales + (1-dom_sales/100)*100 - 
+  return(round((dom_sales + (1-dom_sales/100)*100 - 
                   tot_sales*dom_costs/100 -
-                    (1-dom_costs/100)*tot_sales - 0.01*new_tax_rate*(dom_sales+
-                      (1-dom_sales/100)*100 - tot_sales*dom_costs/100-
-                        (1-dom_costs/100)*tot_sales))*10)/10
-    )
+                  (1-dom_costs/100)*tot_sales - 0.01*new_tax_rate*(dom_sales+
+                                                                     (1-dom_sales/100)*100 - tot_sales*dom_costs/100-
+                                                                     (1-dom_costs/100)*tot_sales))*10)/10
+  )
 }
 
 NTR_BA_USS <- function(dom_costs, dom_sales, tot_sales, currency_adj, import_cost, new_tax_rate){
-    return(round(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))-
-                  ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0),digits = 1)
-    )
+  return(round(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))-
+                                  ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0),digits = 1)
+  )
 }
 
 NTR_BA_TB <- function(dom_costs, dom_sales, tot_sales, currency_adj, import_cost, new_tax_rate){
-    return(round(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))- 
-                  ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0)
-                    - tot_sales*dom_costs/100,digits = 1)
-    )
+  return(round(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))- 
+                                  ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0)
+               - tot_sales*dom_costs/100,digits = 1)
+  )
 }
 
 NTR_BA_ATP <- function(dom_costs, dom_sales, tot_sales, currency_adj, import_cost, new_tax_rate){
-    return(round(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))-
-                               ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0) +
-        (1-dom_sales/100)*100*(1-new_tax_rate*currency_adj/10000) - tot_sales*dom_costs/100 -
-        (1-dom_costs/100)*tot_sales*(1-new_tax_rate*currency_adj/10000) -
-        (0.01*new_tax_rate*(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))-
-                                                           ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0) 
-                                  - tot_sales*dom_costs/100)),1))
+  return(round(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))-
+                                  ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0) +
+                 (1-dom_sales/100)*100*(1-new_tax_rate*currency_adj/10000) - tot_sales*dom_costs/100 -
+                 (1-dom_costs/100)*tot_sales*(1-new_tax_rate*currency_adj/10000) -
+                 (0.01*new_tax_rate*(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))-
+                                                        ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0) 
+                                     - tot_sales*dom_costs/100)),1))
 }
 
 test_that("Testing Original Tax Rate #1", {  
@@ -95,4 +95,34 @@ test_that("Testing New Tax Rate with Border Adjustment #4", {
   expect_that( result_USS == 58.4, is_true() )
   expect_that( result_TB == 35.1, is_true() )
   expect_that( result_ATP == 11.7, is_true() )
+})
+
+test_that("Testing New Tax Rate with Border Adjustment #5", {  
+  result_USS = NTR_BA_USS(100,36,64,63,92,98)
+  result_TB = NTR_BA_TB(100,36,64,63,92,98)
+  result_ATP = NTR_BA_ATP(100,36,64,63,92,98)
+  expect_that( result_TB, is_a("numeric") )
+  expect_that( result_ATP, is_a("numeric") )
+  expect_that( result_USS, is_a("numeric") )
+  expect_that( length(result_TB), equals(1) )
+  expect_that( length(result_ATP), equals(1) )
+  expect_that( length(result_USS), equals(1) )
+  expect_that( result_USS == 36, is_true() )
+  expect_that( result_TB == -28, is_true() )
+  expect_that( result_ATP == 23.9, is_true() )
+})
+
+test_that("Testing New Tax Rate with Border Adjustment #6", {  
+  result_USS = NTR_BA_USS(80,9,23,16,40,0)
+  result_TB = NTR_BA_TB(80,9,23,16,40,0)
+  result_ATP = NTR_BA_ATP(80,9,23,16,40,0)
+  expect_that( result_TB, is_a("numeric") )
+  expect_that( result_ATP, is_a("numeric") )
+  expect_that( result_USS, is_a("numeric") )
+  expect_that( length(result_TB), equals(1) )
+  expect_that( length(result_ATP), equals(1) )
+  expect_that( length(result_USS), equals(1) )
+  expect_that( result_USS == 9, is_true() )
+  expect_that( result_TB == -9.4, is_true() )
+  expect_that( result_ATP == 77, is_true() )
 })

--- a/tests/test-numeric.R
+++ b/tests/test-numeric.R
@@ -49,9 +49,50 @@ NTR_BA_ATP <- function(dom_costs, dom_sales, tot_sales, currency_adj, import_cos
                                   - tot_sales*dom_costs/100)),1))
 }
 
-test_that("NTR.BA after tax profit", {  
-    results = NTR_BA_ATP(20,50,30,80,55,25)
-    expect_that( results, is_a("numeric") )
-    expect_that( length(results), equals(1) )
-    expect_that( results == 53.8, is_true() )
+test_that("Testing Original Tax Rate #1", {  
+  result_TB = OTR_TB(7,0,25)
+  result_ATP = OTR_ATP(7,0,25)
+  expect_that( result_TB, is_a("numeric") )
+  expect_that( result_ATP, is_a("numeric") )
+  expect_that( length(result_TB), equals(1) )
+  expect_that( length(result_ATP), equals(1) )
+  expect_that( result_TB == 75, is_true() )
+  expect_that( result_ATP == 48.8, is_true() )
+})
+
+test_that("Testing New Tax Rate #2", {  
+  result_TB = NTR_TB(71,27,95)
+  result_ATP = NTR_ATP(71,27,95,41)
+  expect_that( result_TB, is_a("numeric") )
+  expect_that( result_ATP, is_a("numeric") )
+  expect_that( length(result_TB), equals(1) )
+  expect_that( length(result_ATP), equals(1) )
+  expect_that( result_TB == 5, is_true() )
+  expect_that( result_ATP == 2.9, is_true() )
+})
+
+test_that("Testing New Tax Rate #3", {  
+  result_TB = NTR_TB(93,23,37)
+  result_ATP = NTR_ATP(93,23,37,87)
+  expect_that( result_TB, is_a("numeric") )
+  expect_that( result_ATP, is_a("numeric") )
+  expect_that( length(result_TB), equals(1) )
+  expect_that( length(result_ATP), equals(1) )
+  expect_that( result_TB == 63, is_true() )
+  expect_that( result_ATP == 8.2, is_true() )
+})
+
+test_that("Testing New Tax Rate with Border Adjustment #4", {  
+  result_USS = NTR_BA_USS(28,58,83,80,27,27)
+  result_TB = NTR_BA_TB(28,58,83,80,27,27)
+  result_ATP = NTR_BA_ATP(28,58,83,80,27,27)
+  expect_that( result_TB, is_a("numeric") )
+  expect_that( result_ATP, is_a("numeric") )
+  expect_that( result_USS, is_a("numeric") )
+  expect_that( length(result_TB), equals(1) )
+  expect_that( length(result_ATP), equals(1) )
+  expect_that( length(result_USS), equals(1) )
+  expect_that( result_USS == 58.4, is_true() )
+  expect_that( result_TB == 35.1, is_true() )
+  expect_that( result_ATP == 11.7, is_true() )
 })

--- a/tests/test-numeric.R
+++ b/tests/test-numeric.R
@@ -1,3 +1,44 @@
+OTR_TB <- function(dom_costs, dom_sales, tot_sales){
+    return(round(dom_sales+(1-dom_sales/100)*100 
+                  -tot_sales*dom_costs/100-(1-dom_costs/100)*tot_sales,digits = 1))
+}
+
+OTR_ATP <- function(dom_costs, dom_sales, tot_sales){
+    return(round((dom_sales+(1-dom_sales/100)*100 - 
+                  tot_sales*dom_costs/100-(1-dom_costs/100)*tot_sales- 
+                    (0.01*35*(dom_sales+(1-dom_sales/100)*100-
+                      tot_sales*dom_costs/100-(1-dom_costs/100)*tot_sales)))*10)/10
+    )
+}
+
+NTR_TB <- function(dom_costs, dom_sales, tot_sales){
+    return(round(dom_sales + (1-dom_sales/100)*100 -
+                  tot_sales*dom_costs/100- (1-dom_costs/100)*tot_sales,digits = 1)
+    )
+}
+
+NTR_ATP <- function(dom_costs, dom_sales, tot_sales, new_tax_rate){
+    return(round((dom_sales + (1-dom_sales/100)*100 - 
+                  tot_sales*dom_costs/100 -
+                    (1-dom_costs/100)*tot_sales - 0.01*new_tax_rate*(dom_sales+
+                      (1-dom_sales/100)*100 - tot_sales*dom_costs/100-
+                        (1-dom_costs/100)*tot_sales))*10)/10
+    )
+}
+
+NTR_BA_USS <- function(dom_costs, dom_sales, tot_sales, currency_adj, import_cost, new_tax_rate){
+    return(round(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))-
+                  ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0),digits = 1)
+    )
+}
+
+NTR_BA_TB <- function(dom_costs, dom_sales, tot_sales, currency_adj, import_cost, new_tax_rate){
+    return(round(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))- 
+                  ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0)
+                    - tot_sales*dom_costs/100,digits = 1)
+    )
+}
+
 NTR_BA_ATP <- function(dom_costs, dom_sales, tot_sales, currency_adj, import_cost, new_tax_rate){
     return(round(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))-
                                ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0) +

--- a/tests/test-numeric.R
+++ b/tests/test-numeric.R
@@ -1,0 +1,16 @@
+NTR_BA_ATP <- function(dom_costs, dom_sales, tot_sales, currency_adj, import_cost, new_tax_rate){
+    return(round(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))-
+                               ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0) +
+        (1-dom_sales/100)*100*(1-new_tax_rate*currency_adj/10000) - tot_sales*dom_costs/100 -
+        (1-dom_costs/100)*tot_sales*(1-new_tax_rate*currency_adj/10000) -
+        (0.01*new_tax_rate*(dom_sales + max((((1-dom_costs/100)*tot_sales*(1-currency_adj/100))-
+                                                           ((1-dom_sales/100)*100*(1-currency_adj/100)))*new_tax_rate*(1/(1-new_tax_rate/100))*import_cost/10000,0) 
+                                  - tot_sales*dom_costs/100)),1))
+}
+
+test_that("NTR.BA after tax profit", {  
+    results = NTR_BA_ATP(20,50,30,80,55,25)
+    expect_that( results, is_a("numeric") )
+    expect_that( length(results), equals(1) )
+    expect_that( results == 53.8, is_true() )
+})


### PR DESCRIPTION
Per discussions in #7, test suites are helpful when changes are being made to border adjustment calculators. This PR thus adds test suite to guard against potential bugs from being introduced. 

`basic-test.R` is supposed to test for connectivities, for some reasons, however, the script is not working properly. 

`test-numeric.R`, on the other hand, is designed to prevent numeric errors. More test components within `test-numeric.R` are coming soon. 

An `README.md` will be added after finishing all these scripts.